### PR TITLE
return predicted value

### DIFF
--- a/EmoPy/src/fermodel.py
+++ b/EmoPy/src/fermodel.py
@@ -51,7 +51,7 @@ class FERModel:
         :param images: image file (jpg or png format)
         """
         image = misc.imread(image_file)
-        self.predict_from_ndarray(image)
+        return self.predict_from_ndarray(image)
 
     def predict_from_ndarray(self, image_array):
         """


### PR DESCRIPTION
I have just made a return on the value predicted. As on this function: https://github.com/thoughtworksarts/EmoPy/blob/master/EmoPy/src/fermodel.py#L123.  There is a return and a comment of the print which is useless, because we need a return of value and not an impression.
In this example: https://github.com/thoughtworksarts/EmoPy/blob/master/EmoPy/examples/fermodel_example_webcam.py#L31, the variable are always NoneType, and we need to get the prediction for this example or on another application.
thanks