### PR TITLE
fix bug when use pycharm remote

### DIFF
--- a/EmoPy/src/callback.py
+++ b/EmoPy/src/callback.py
@@ -1,5 +1,5 @@
-import matplotlib as mpl
-mpl.use('TkAgg')
+# import matplotlib as mpl
+# mpl.use('TkAgg')
 import matplotlib.pyplot as plt
 from keras.callbacks import Callback
 import os


### PR DESCRIPTION
TkAgg cannot be imported when using pycharm remote.

If run in terminal, TkAgg is not necessary.
![snipaste20200322_205218](https://user-images.githubusercontent.com/12939345/77249896-3d1a4680-6c7f-11ea-8c61-64b159cb99c4.png)


ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running